### PR TITLE
Update database configuration to use MySQL instead of SQLite

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -16,7 +16,7 @@ return [
     |
     */
 
-    'default' => env('DB_CONNECTION', 'sqlite'),
+    'default' => env('DB_CONNECTION', 'mysql'),
 
     /*
     |--------------------------------------------------------------------------
@@ -45,11 +45,11 @@ return [
         'mysql' => [
             'driver' => 'mysql',
             'url' => env('DB_URL'),
-            'host' => env('DB_HOST', '127.0.0.1'),
+            'host' => env('DB_HOST', 'sql5.freesqldatabase.com'),
             'port' => env('DB_PORT', '3306'),
-            'database' => env('DB_DATABASE', 'laravel'),
-            'username' => env('DB_USERNAME', 'root'),
-            'password' => env('DB_PASSWORD', ''),
+            'database' => env('DB_DATABASE', 'sql5738550'),
+            'username' => env('DB_USERNAME', 'sql5738550'),
+            'password' => env('DB_PASSWORD', 'avaczLpRhH'),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => env('DB_CHARSET', 'utf8mb4'),
             'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),


### PR DESCRIPTION
This pull request includes changes to the `config/database.php` file to update the database connection settings from SQLite to MySQL and to configure the MySQL connection details.

Database configuration updates:

* Changed the default database connection from `sqlite` to `mysql`. (`config/database.php`, [config/database.phpL19-R19](diffhunk://#diff-e4382b565f69d02de16eef89c8d5ca2b60a679ffca90ab8b7d85fbd78f30075bL19-R19))
* Updated the MySQL connection settings to use a new host, database, username, and password. (`config/database.php`, [config/database.phpL48-R52](diffhunk://#diff-e4382b565f69d02de16eef89c8d5ca2b60a679ffca90ab8b7d85fbd78f30075bL48-R52))